### PR TITLE
Fix socket failure check and prevent double responses

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -53,7 +53,7 @@ void start_server() {
 
     // this creates and try catches the web socket
     server_fd = socket(AF_INET, SOCK_STREAM, 0);
-    if (server_fd == 0) {
+    if (server_fd < 0) {
         std::cerr << "Socket failed\n";
         return;
     }
@@ -81,79 +81,69 @@ void start_server() {
     std::cout << "Received request:\n" << buffer << "\n";
 
     if (strstr(buffer, "POST /login")) {
-    // Step 1: Find where the headers end (two newlines = body start)
-    char *body = strstr(buffer, "\r\n\r\n");
-    if (body != NULL) {
-        body += 4; // skip past the \r\n\r\n
-        std::string bodyStr(body);
-        std::cout << "Parsed body: " << bodyStr << "\n";
+        // Step 1: Find where the headers end (two newlines = body start)
+        char *body = strstr(buffer, "\r\n\r\n");
+        if (body != NULL) {
+            body += 4; // skip past the \r\n\r\n
+            std::string bodyStr(body);
+            std::cout << "Parsed body: " << bodyStr << "\n";
 
-        // Step 2: Simple parsing (you can improve later)
-        std::string username;
-        std::string password;
+            // Step 2: Simple parsing (you can improve later)
+            std::string username;
+            std::string password;
 
-        size_t userPos = bodyStr.find("username=");
-        size_t passPos = bodyStr.find("password=");
-        if (userPos != std::string::npos && passPos != std::string::npos) {
-            username = bodyStr.substr(userPos + 9, passPos - userPos - 10); // crude extraction
-            password = bodyStr.substr(passPos + 9);
+            size_t userPos = bodyStr.find("username=");
+            size_t passPos = bodyStr.find("password=");
+            if (userPos != std::string::npos && passPos != std::string::npos) {
+                username = bodyStr.substr(userPos + 9, passPos - userPos - 10); // crude extraction
+                password = bodyStr.substr(passPos + 9);
+            }
+
+            std::string responseBody = "Welcome, " + username + "!";
+
+            std::string response =
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Type: text/plain\r\n"
+                "Content-Length: " + std::to_string(responseBody.size()) + "\r\n\r\n" +
+                responseBody;
+
+            write(new_socket, response.c_str(), response.size());
+        } else {
+            // No body found
+            const char *bad = "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n";
+            write(new_socket, bad, strlen(bad));
+        }
+    } else if (strstr(buffer, "GET /user/")) {
+        // Extract the username from the URL
+        std::string request(buffer);
+        size_t start = request.find("GET /user/") + 10;
+        size_t end = request.find(" ", start); // End of URL path
+        std::string username = request.substr(start, end - start);
+
+        std::cout << "Looking up user: " << username << "\n";
+
+        // Check if user exists
+        if (fakeDB.find(username) != fakeDB.end()) {
+            User u = fakeDB[username];
+            std::string json = "{ \"username\": \"" + u.username + "\", \"age\": " + std::to_string(u.age) + " }";
+
+            std::string response =
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Type: application/json\r\n"
+                "Content-Length: " + std::to_string(json.size()) + "\r\n\r\n" +
+                json;
+
+            write(new_socket, response.c_str(), response.size());
+        } else {
+            const char *notfound = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n";
+            write(new_socket, notfound, strlen(notfound));
         }
 
-        std::string responseBody = "Welcome, " + username + "!";
-
-        std::string response = 
-            "HTTP/1.1 200 OK\r\n"
-            "Content-Type: text/plain\r\n"
-            "Content-Length: " + std::to_string(responseBody.size()) + "\r\n\r\n" +
-            responseBody;
-
-        write(new_socket, response.c_str(), response.size());
     } else {
-        // No body found
-        const char *bad = "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n";
+        const char *bad = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n";
         write(new_socket, bad, strlen(bad));
     }
-    close(new_socket);
-}
 
-// Handle GET /user/username
-if (strstr(buffer, "GET /user/")) {
-    // Extract the username from the URL
-    std::string request(buffer);
-    size_t start = request.find("GET /user/") + 10;
-    size_t end = request.find(" ", start); // End of URL path
-    std::string username = request.substr(start, end - start);
-
-    std::cout << "Looking up user: " << username << "\n";
-
-    // Check if user exists
-    if (fakeDB.find(username) != fakeDB.end()) {
-        User u = fakeDB[username];
-        std::string json = "{ \"username\": \"" + u.username + "\", \"age\": " + std::to_string(u.age) + " }";
-        
-        std::string response =
-            "HTTP/1.1 200 OK\r\n"
-            "Content-Type: application/json\r\n"
-            "Content-Length: " + std::to_string(json.size()) + "\r\n\r\n" +
-            json;
-
-        write(new_socket, response.c_str(), response.size());
-    } else {
-        const char *notfound = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n";
-        write(new_socket, notfound, strlen(notfound));
-    }
-
-    close(new_socket);
-}
-
-
-    // Send basic response
-
-    const char *whatsgood = "HTTP/1.1 200 OK\nContent-Type: text/plain\nContent-Length: 12\n\nWhats good";
-    write(new_socket, whatsgood, strlen(whatsgood));   
-
-    const char *response = "HTTP/1.1 200 OK\nContent-Type: text/plain\nContent-Length: 12\n\nI see this";
-    write(new_socket, response, strlen(response));
     close(new_socket);
 }
 


### PR DESCRIPTION
## Summary
- improve socket error check in `start_server`
- refactor request handling to avoid double writes and return 404 for unknown routes

## Testing
- `make`
- `./server &` *(fails to bind if previous server is running)*
- `curl -X GET http://localhost:8080/user/camden`
- `curl -i -X POST -d "username=alex&password=test" http://localhost:8080/login`

------
https://chatgpt.com/codex/tasks/task_e_6841047874b08331a25f852da19d153f